### PR TITLE
Add websocket peer connection tests and server logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module upgraded-potato
 
 go 1.23.8
+
+require github.com/gorilla/websocket v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/pkg/netcode/server.go
+++ b/pkg/netcode/server.go
@@ -1,9 +1,99 @@
 package netcode
 
+import (
+    "net"
+    "net/http"
+    "sync"
+
+    "github.com/gorilla/websocket"
+)
+
 type Server struct {
-	Address string
+    Address  string
+    upgrader websocket.Upgrader
+
+    listener net.Listener
+    srv      *http.Server
+    mu       sync.Mutex
+    conns    map[*websocket.Conn]struct{}
 }
 
 func NewServer(addr string) *Server {
-	return &Server{Address: addr}
+    s := &Server{
+        Address: addr,
+        upgrader: websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }},
+        conns:    make(map[*websocket.Conn]struct{}),
+    }
+    return s
+}
+
+// Start begins listening for websocket connections on the server's address.
+func (s *Server) Start() error {
+    ln, err := net.Listen("tcp", s.Address)
+    if err != nil {
+        return err
+    }
+    s.listener = ln
+    mux := http.NewServeMux()
+    mux.HandleFunc("/ws", s.handleWS)
+    srv := &http.Server{Handler: mux}
+    s.srv = srv
+    go srv.Serve(ln)
+    return nil
+}
+
+// Stop shuts down the server and closes all active connections.
+func (s *Server) Stop() error {
+    if s.srv != nil {
+        _ = s.srv.Close()
+    }
+    if s.listener != nil {
+        _ = s.listener.Close()
+    }
+    s.mu.Lock()
+    for c := range s.conns {
+        c.Close()
+    }
+    s.conns = make(map[*websocket.Conn]struct{})
+    s.mu.Unlock()
+    return nil
+}
+
+func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
+    s.mu.Lock()
+    if len(s.conns) >= 3 {
+        s.mu.Unlock()
+        http.Error(w, "connection limit reached", http.StatusServiceUnavailable)
+        return
+    }
+    s.mu.Unlock()
+
+    conn, err := s.upgrader.Upgrade(w, r, nil)
+    if err != nil {
+        return
+    }
+
+    s.mu.Lock()
+    s.conns[conn] = struct{}{}
+    s.mu.Unlock()
+
+    go s.readLoop(conn)
+}
+
+func (s *Server) readLoop(c *websocket.Conn) {
+    defer func() {
+        s.mu.Lock()
+        delete(s.conns, c)
+        s.mu.Unlock()
+        c.Close()
+    }()
+    for {
+        mt, msg, err := c.ReadMessage()
+        if err != nil {
+            break
+        }
+        if err := c.WriteMessage(mt, msg); err != nil {
+            break
+        }
+    }
 }

--- a/pkg/netcode/server_test.go
+++ b/pkg/netcode/server_test.go
@@ -1,6 +1,12 @@
 package netcode
 
-import "testing"
+import (
+    "net/http"
+    "testing"
+    "time"
+
+    "github.com/gorilla/websocket"
+)
 
 func TestNewServer(t *testing.T) {
 	addr := "localhost:8080"
@@ -11,4 +17,47 @@ func TestNewServer(t *testing.T) {
 	if s.Address != addr {
 		t.Fatalf("expected address %s, got %s", addr, s.Address)
 	}
+}
+
+func TestServerPeerConnections(t *testing.T) {
+    s := NewServer("127.0.0.1:0")
+    if err := s.Start(); err != nil {
+        t.Fatalf("failed to start server: %v", err)
+    }
+    defer s.Stop()
+
+    addr := s.listener.Addr().String()
+    dial := func() (*websocket.Conn, *http.Response, error) {
+        return websocket.DefaultDialer.Dial("ws://"+addr+"/ws", nil)
+    }
+
+    var conns []*websocket.Conn
+    for i := 0; i < 3; i++ {
+        c, _, err := dial()
+        if err != nil {
+            t.Fatalf("dial %d: %v", i, err)
+        }
+        conns = append(conns, c)
+        if err := c.WriteMessage(websocket.TextMessage, []byte("hello")); err != nil {
+            t.Fatalf("write %d: %v", i, err)
+        }
+        _, msg, err := c.ReadMessage()
+        if err != nil {
+            t.Fatalf("read %d: %v", i, err)
+        }
+        if string(msg) != "hello" {
+            t.Fatalf("expected echo hello, got %s", msg)
+        }
+    }
+
+    if c, _, err := dial(); err == nil {
+        c.Close()
+        t.Fatal("expected connection limit reached")
+    }
+
+    // allow goroutines to clean up
+    time.Sleep(50 * time.Millisecond)
+    for _, c := range conns {
+        c.Close()
+    }
 }


### PR DESCRIPTION
## Summary
- add gorilla websocket dependency
- implement websocket server with connection limit and echo loop
- add tests for connection limits and message echo

## Testing
- `go test ./pkg/netcode -v`
- `go test ./... -v`


------
https://chatgpt.com/codex/tasks/task_e_686adf67b9a483248f88bc2f24af664c