### PR TITLE
Fix CI by generating protobufs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.0
+      - run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.0
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - run: go generate ./...
       - run: go test -json ./... > report.json
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.0
+      - run: go generate ./...
       - run: go test -json ./... > report.json
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.0
       - run: go generate ./...
       - run: go test -json ./... > report.json


### PR DESCRIPTION
## Summary
- run `go generate` in CI so protobuf types exist
- install the `protoc-gen-go` plugin for generation

## Testing
- `go generate ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686af09c78c483248e7893ba9efe30c6