### PR TITLE
Add lobby tests and stub service

### DIFF
--- a/pkg/lobby/generate.go
+++ b/pkg/lobby/generate.go
@@ -1,0 +1,3 @@
+package lobby
+
+//go:generate protoc --go_out=paths=source_relative:. message.proto

--- a/pkg/lobby/lobby.go
+++ b/pkg/lobby/lobby.go
@@ -1,0 +1,38 @@
+package lobby
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrNotImplemented = errors.New("not implemented")
+
+// LobbyService manages lobby lifecycle and queries.
+type LobbyService interface {
+	CreateLobby(ctx context.Context, hostID string, maxPlayers int, public bool) (string, error)
+	ListLobbies(ctx context.Context, requesterID string) ([]*LobbySummary, error)
+	SearchLobbies(ctx context.Context, requesterID, query string) ([]*LobbySummary, error)
+	BlockUser(ctx context.Context, requesterID, targetID string) error
+}
+
+type LobbyServer struct{}
+
+func NewLobbyServer() *LobbyServer {
+	return &LobbyServer{}
+}
+
+func (ls *LobbyServer) CreateLobby(ctx context.Context, hostID string, maxPlayers int, public bool) (string, error) {
+	return "", ErrNotImplemented
+}
+
+func (ls *LobbyServer) ListLobbies(ctx context.Context, requesterID string) ([]*LobbySummary, error) {
+	return nil, ErrNotImplemented
+}
+
+func (ls *LobbyServer) SearchLobbies(ctx context.Context, requesterID, query string) ([]*LobbySummary, error) {
+	return nil, ErrNotImplemented
+}
+
+func (ls *LobbyServer) BlockUser(ctx context.Context, requesterID, targetID string) error {
+	return ErrNotImplemented
+}

--- a/pkg/lobby/lobby_test.go
+++ b/pkg/lobby/lobby_test.go
@@ -1,0 +1,76 @@
+package lobby
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCreateLobbyGeneratesCode(t *testing.T) {
+	ls := NewLobbyServer()
+	code, err := ls.CreateLobby(context.Background(), "host1", 4, true)
+	if err != nil {
+		t.Fatalf("CreateLobby returned error: %v", err)
+	}
+	if len(code) != 6 {
+		t.Fatalf("expected lobby code length 6, got %d", len(code))
+	}
+}
+
+func TestListLobbiesExcludesBlocked(t *testing.T) {
+	ls := NewLobbyServer()
+	hostID := "host1"
+	userID := "user1"
+	if _, err := ls.CreateLobby(context.Background(), hostID, 4, true); err != nil {
+		t.Fatalf("CreateLobby: %v", err)
+	}
+	if err := ls.BlockUser(context.Background(), hostID, userID); err != nil {
+		t.Fatalf("BlockUser: %v", err)
+	}
+	lobbies, err := ls.ListLobbies(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("ListLobbies: %v", err)
+	}
+	if len(lobbies) != 0 {
+		t.Fatalf("expected no lobbies, got %d", len(lobbies))
+	}
+}
+
+func TestSearchLobbiesMatchesCodeOrHost(t *testing.T) {
+	ls := NewLobbyServer()
+	if _, err := ls.CreateLobby(context.Background(), "Alpha", 4, true); err != nil {
+		t.Fatalf("CreateLobby: %v", err)
+	}
+	if _, err := ls.CreateLobby(context.Background(), "Beta", 4, true); err != nil {
+		t.Fatalf("CreateLobby: %v", err)
+	}
+	res, err := ls.SearchLobbies(context.Background(), "user", "Al")
+	if err != nil {
+		t.Fatalf("SearchLobbies: %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatalf("expected results for query")
+	}
+}
+
+func TestBlockUserPreventsJoin(t *testing.T) {
+	ls := NewLobbyServer()
+	hostID := "host2"
+	userID := "user2"
+	code, err := ls.CreateLobby(context.Background(), hostID, 4, true)
+	if err != nil {
+		t.Fatalf("CreateLobby: %v", err)
+	}
+	if err := ls.BlockUser(context.Background(), hostID, userID); err != nil {
+		t.Fatalf("BlockUser: %v", err)
+	}
+	// Attempt to list lobbies should not include blocked host
+	lobbies, err := ls.ListLobbies(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("ListLobbies: %v", err)
+	}
+	for _, l := range lobbies {
+		if l.LobbyCode == code {
+			t.Fatalf("blocked lobby should not be listed")
+		}
+	}
+}

--- a/pkg/lobby/message.proto
+++ b/pkg/lobby/message.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+package lobby;
+option go_package = "upgraded-potato/pkg/lobby";
+
+message CreateLobbyRequest {
+  string host_id = 1;
+  uint32 max_players = 2;
+  bool public = 3;
+}
+
+message CreateLobbyResponse {
+  string lobby_code = 1;
+  bool success = 2;
+}
+
+message ListLobbiesRequest {}
+
+message LobbySummary {
+  string lobby_code = 1;
+  string host_id = 2;
+  uint32 players = 3;
+  uint32 max_players = 4;
+}
+
+message ListLobbiesResponse {
+  repeated LobbySummary lobbies = 1;
+}
+
+message SearchLobbiesRequest {
+  string query = 1;
+}
+
+message SearchLobbiesResponse {
+  repeated LobbySummary results = 1;
+}
+
+message BlockUserRequest {
+  string user_id = 1;
+}
+
+message BlockUserResponse {
+  bool success = 1;
+}


### PR DESCRIPTION
## Summary
- add lobby protobuf messages
- add stub `LobbyServer` implementing `LobbyService`
- write failing tests describing lobby behaviour

## Testing
- `go test ./...` *(fails: CreateLobby returned error: not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_686b0f291c408324b7353d90f5749919