### PR TITLE
Implement in-memory lobby service

### DIFF
--- a/pkg/lobby/lobby.go
+++ b/pkg/lobby/lobby.go
@@ -2,7 +2,11 @@ package lobby
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
+	"math/big"
+	"strings"
+	"sync"
 )
 
 var ErrNotImplemented = errors.New("not implemented")
@@ -15,24 +19,124 @@ type LobbyService interface {
 	BlockUser(ctx context.Context, requesterID, targetID string) error
 }
 
-type LobbyServer struct{}
+type Lobby struct {
+	Code       string
+	HostID     string
+	MaxPlayers int
+	Public     bool
+	Players    int
+}
+
+type LobbyServer struct {
+	mu      sync.Mutex
+	lobbies map[string]*Lobby
+	blocked map[string]map[string]bool
+}
 
 func NewLobbyServer() *LobbyServer {
-	return &LobbyServer{}
+	return &LobbyServer{
+		lobbies: make(map[string]*Lobby),
+		blocked: make(map[string]map[string]bool),
+	}
+}
+
+var codeChars = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+func randomCode() (string, error) {
+	b := make([]rune, 6)
+	for i := range b {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(codeChars))))
+		if err != nil {
+			return "", err
+		}
+		b[i] = codeChars[n.Int64()]
+	}
+	return string(b), nil
 }
 
 func (ls *LobbyServer) CreateLobby(ctx context.Context, hostID string, maxPlayers int, public bool) (string, error) {
-	return "", ErrNotImplemented
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	var code string
+	var err error
+	for {
+		code, err = randomCode()
+		if err != nil {
+			return "", err
+		}
+		if _, exists := ls.lobbies[code]; !exists {
+			break
+		}
+	}
+
+	ls.lobbies[code] = &Lobby{
+		Code:       code,
+		HostID:     hostID,
+		MaxPlayers: maxPlayers,
+		Public:     public,
+		Players:    1,
+	}
+
+	return code, nil
 }
 
 func (ls *LobbyServer) ListLobbies(ctx context.Context, requesterID string) ([]*LobbySummary, error) {
-	return nil, ErrNotImplemented
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	var res []*LobbySummary
+	for _, l := range ls.lobbies {
+		if !l.Public {
+			continue
+		}
+		if blocked, ok := ls.blocked[l.HostID]; ok && blocked[requesterID] {
+			continue
+		}
+		res = append(res, &LobbySummary{
+			LobbyCode:  l.Code,
+			HostId:     l.HostID,
+			Players:    uint32(l.Players),
+			MaxPlayers: uint32(l.MaxPlayers),
+		})
+	}
+	return res, nil
 }
 
 func (ls *LobbyServer) SearchLobbies(ctx context.Context, requesterID, query string) ([]*LobbySummary, error) {
-	return nil, ErrNotImplemented
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	q := strings.ToLower(query)
+	var res []*LobbySummary
+	for _, l := range ls.lobbies {
+		if !l.Public {
+			continue
+		}
+		if blocked, ok := ls.blocked[l.HostID]; ok && blocked[requesterID] {
+			continue
+		}
+		if strings.Contains(strings.ToLower(l.Code), q) || strings.Contains(strings.ToLower(l.HostID), q) {
+			res = append(res, &LobbySummary{
+				LobbyCode:  l.Code,
+				HostId:     l.HostID,
+				Players:    uint32(l.Players),
+				MaxPlayers: uint32(l.MaxPlayers),
+			})
+		}
+	}
+	return res, nil
 }
 
 func (ls *LobbyServer) BlockUser(ctx context.Context, requesterID, targetID string) error {
-	return ErrNotImplemented
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	m, ok := ls.blocked[requesterID]
+	if !ok {
+		m = make(map[string]bool)
+		ls.blocked[requesterID] = m
+	}
+	m[targetID] = true
+	return nil
 }


### PR DESCRIPTION
## Summary
- implement `LobbyServer` with in-memory lobby tracking
- add random lobby code generation
- support listing, searching, and blocking lobbies

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686b1f86dcc48324826ae2b886d9992f